### PR TITLE
Add string syntax and parse word

### DIFF
--- a/e
+++ b/e
@@ -1,3 +1,6 @@
 (
-  "hello" $e "hi" $e gc e print
+  "hello" $e
+  "hi" $e
+  gc
+  e print
 )

--- a/e
+++ b/e
@@ -1,0 +1,3 @@
+(
+  "hello" $e "hi" $e gc e print
+)

--- a/examples/forsp.fp
+++ b/examples/forsp.fp
@@ -9,7 +9,7 @@
   ($f $t $c $fn ^f ^t ^c fn)     $endif
 
   ; object type predicate functions
-  (tag 0 eq) $is-nil  (tag 1 eq) $is-atom (tag 3 eq) $is-pair (tag 4 eq) $is-clos
+  (tag 0 eq) $is-nil (tag 1 eq) $is-atom (tag 3 eq) $is-pair (tag 4 eq) $is-clos (tag 5 eq) $is-prim (tag 6 eq) $is-str
   ($x ('() 't (^x is-pair) if) 't (^x is-nil) if) $is-list
 
   ; recursion via y-combinator

--- a/examples/strings.fp
+++ b/examples/strings.fp
@@ -1,0 +1,13 @@
+(
+  0 make-string print
+
+  2 make-string $str
+  str 0 72 string-poke
+  str 1 105 string-poke
+  str print
+
+  "Hello world!" print
+  "Hello\nworld!" print
+
+  "\x3a\x29" print
+)


### PR DESCRIPTION
```string syntax: atoms that start with " can contain forbidden characters including spaces
note: you have to escape \ with \\ and " with \"
note: print now checks whether the atom contains illegal characters and prints it as a string if it does

parse word: it has the signature of [atom offset -> atom new-offset object] to treat atom as a string and start reading an object at offset in the string and increment the offset on the stack and add the read object
```