### PR TITLE
Set `build.sh` to C11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CFLAGS="-std=c99 -Wall -Werror -O2 -g"
+CFLAGS="-std=c11 -Wall -Werror -O2 -g"
 LDFLAGS=""
 
 gcc $CFLAGS -o forsp forsp.c $LDFLAGS


### PR DESCRIPTION
Just update `build.sh` for #9 with C11. This assumes DR 499, which was retroactively applied to C11, but specifying C17 would ensure this is covered, in case a compiler (for some reason) mangles structs in an anonymous union (but this is unlikely, and the spec does cover it now).