### PR TITLE
Add linter for C/C++ github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,31 @@ on:
     push:
         branches:
             - main
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [ "main" ]
+    schedule:
+        - cron: '39 17 * * 0'
 jobs:
-    first_job:
+    clinter:
+        name: A Clinter
         runs-on: ubuntu-latest
-        name: My 1st Job
+        permissions:
+            contents: read
+            security-events: write
+            actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
         steps:
-            - name: First thing
-              run: echo "This is the first thing to do"
-              shell: bash
+          - name: First thing
+            run: echo "This is the first thing to do"
+            shell: bash
+          - name: Checkout code
+            uses: actions/checkout@v4
+
+          - name: configure
+            run: ./configure
+          - name: make
+            run: make
+          - name: make check
+            run: make check
+          - name: make distcheck
+            run: make distcheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,15 @@ jobs:
             shell: bash
           - name: Checkout code
             uses: actions/checkout@v4
-
-          - name: configure
-            run: ./configure
-          - name: make
-            run: make
-          - name: make check
-            run: make check
-          - name: make distcheck
-            run: make distcheck
+          - uses: cpp-linter/cpp-linter-action@v2
+            id: linter
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+                style: 'file'  # Use .clang-format config file
+                tidy-checks: '' # Use .clang-tidy config file
+                # only 'update' a single comment in a pull request's thread.
+                thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+          - name: Fail fast?!
+            if: steps.linter.outputs.checks-failed > 0
+            run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v4
           - name: First thing
-            run: echo "Run the build" || ./build.sh
+            run: (echo "Run the build" && ./build.sh) || echo "Build failure"
             shell: bash
           - uses: cpp-linter/cpp-linter-action@v2
             id: linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
             shell: bash
           - name: Checkout code
             uses: actions/checkout@v4
+          - name: First thing
+            run: echo "Run the build" || ./build.sh
+            shell: bash
           - uses: cpp-linter/cpp-linter-action@v2
             id: linter
             env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: A first flow
+on:
+    push:
+        branches:
+            - main
+jobs:
+    first_job:
+        runs-on: ubuntu-latest
+        name: My 1st Job
+        steps:
+            - name: First thing
+              run: echo "This is the first thing to do"
+              shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,12 @@
 name: A first flow
 on:
     push:
-        branches:
-            - main
+        branches: [ "main" ] 
+        paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
     pull_request:
         # The branches below must be a subset of the branches above
         branches: [ "main" ]
+        paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
     schedule:
         - cron: '39 17 * * 0'
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ on:
 jobs:
     clinter:
         name: A Clinter
-        runs-on: ubuntu-latest
+        runs-on: self-hosted
+        # runs-on: ubuntu-latest
         permissions:
             contents: read
             security-events: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
             shell: bash
           - name: Checkout code
             uses: actions/checkout@v4
-          - name: First thing
-            run: (echo "Run the build" && ./build.sh) || echo "Build failure"
+          - name: Build runner
+            run: ./build.sh || echo "Build failure"
             shell: bash
           - uses: cpp-linter/cpp-linter-action@v2
             id: linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ on:
 jobs:
     clinter:
         name: A Clinter
-        # runs-on: self-hosted
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ on:
 jobs:
     clinter:
         name: A Clinter
-        runs-on: self-hosted
-        # runs-on: ubuntu-latest
+        # runs-on: self-hosted
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             security-events: write

--- a/forsp.c
+++ b/forsp.c
@@ -22,7 +22,6 @@
 * SOFTWARE.
 *******************************************************************************/
 
-
 #include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/forsp.c
+++ b/forsp.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+
 #define FAIL(...) do { fprintf(stderr, "FAIL: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); abort(); } while (0)
 
 /*******************************************************************

--- a/forsp.c
+++ b/forsp.c
@@ -22,6 +22,7 @@
 * SOFTWARE.
 *******************************************************************************/
 
+
 #include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/forsp.c
+++ b/forsp.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 #define FAIL(...) do { fprintf(stderr, "FAIL: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); abort(); } while (0)
 
 /*******************************************************************


### PR DESCRIPTION
In the midst of making a demonstration of this functionality (cpp-linter github action) for another project.  If you would like this

You can read how this linter functions: https://github.com/cpp-linter/cpp-linter-action

Since it fails on a single error with additional warnings, we would need to decide if some of the checks need to be disabled.  Sample of the failure is here: https://github.com/truedat101/forsp/actions/runs/10978607474
